### PR TITLE
Feature / Add InMemory option for Badger

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ go install github.com/tomiok/queuety/manager@v0.0.4
 
 - [x] At-least-once delivery
 - [x] BadgerDB persistence
-- [ ] In-memory storage option
+- [x] In-memory storage option
 - [x] Docker support
 - [ ] gRPC support
 - [x] Authentication (user/password)

--- a/server/persistence.go
+++ b/server/persistence.go
@@ -3,16 +3,21 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"github.com/dgraph-io/badger/v4"
 	"log"
 	"strings"
+
+	"github.com/dgraph-io/badger/v4"
 )
 
 type BadgerDB struct {
 	*badger.DB
 }
 
-func NewBadger(path string) (*badger.DB, error) {
+func NewBadger(path string, inMemory bool) (*badger.DB, error) {
+	if inMemory {
+		return badger.Open(badger.DefaultOptions("").WithInMemory(true))
+	}
+
 	if path == "" {
 		path = "/data/badger"
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dgraph-io/badger/v4"
 	"io"
 	"log"
 	"net"
 	"time"
+
+	"github.com/dgraph-io/badger/v4"
 )
 
 type Server struct {
@@ -29,11 +30,12 @@ type Server struct {
 }
 
 type Config struct {
-	Protocol   string
-	Port       string
-	BadgerPath string
-	Duration   time.Duration
-	Auth       *Auth
+	Protocol     string
+	Port         string
+	BadgerPath   string
+	Duration     time.Duration
+	Auth         *Auth
+	InMemoryData bool
 }
 
 type Auth struct {
@@ -42,7 +44,7 @@ type Auth struct {
 }
 
 func NewServer(c Config) (*Server, error) {
-	db, err := NewBadger(c.BadgerPath)
+	db, err := NewBadger(c.BadgerPath, c.InMemoryData)
 	if err != nil {
 		return nil, err
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,12 +3,13 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"github.com/dgraph-io/badger/v4"
-	"github.com/google/uuid"
 	"net"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/google/uuid"
 )
 
 func Test_ServerStart(t *testing.T) {
@@ -40,7 +41,7 @@ func Test_ServerStart(t *testing.T) {
 }
 
 func Test_Server(t *testing.T) {
-	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true))
+	db, err := NewBadger("", true)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Este PR resuelve el Issue #3 . 

Se agrega como parámetro de la función NewBadger un parámetro de tipo booleano “inMemory”. También se mantiene esta información a nivel de configuración del Server en la estructura. 